### PR TITLE
Initital commit

### DIFF
--- a/create-alerts-topic.sh
+++ b/create-alerts-topic.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker exec -it kafka-alerts kafka-topics \
+  --create --topic alerts \
+  --bootstrap-server localhost:9092 \
+  --partitions 1 \
+  --replication-factor 1
+

--- a/ls-topics.sh
+++ b/ls-topics.sh
@@ -1,0 +1,3 @@
+docker exec -it kafka-alerts kafka-topics \
+  --list --bootstrap-server localhost:9092
+

--- a/recv-alerts.sh
+++ b/recv-alerts.sh
@@ -1,0 +1,4 @@
+docker exec -it kafka-alerts kafka-console-consumer \
+  --topic alerts --bootstrap-server localhost:9092 \
+  --from-beginning
+

--- a/send-alerts.sh
+++ b/send-alerts.sh
@@ -1,0 +1,3 @@
+docker exec -it kafka-alerts kafka-console-producer \
+  --topic alerts --bootstrap-server localhost:9092
+

--- a/set-storage.sh
+++ b/set-storage.sh
@@ -1,0 +1,6 @@
+docker exec -it kafka-kraft \
+  kafka-storage.sh format \
+  --config /etc/kafka/kafka.properties \
+  --cluster-id $(kafka-storage.sh random-uuid) \
+  --ignore-formatted
+

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+docker rm kafka-alerts
+docker run -d --name kafka-alerts \
+  -p 9092:9092 -p 9093:9093 \
+  -e KAFKA_PROCESS_ROLES=broker,controller \
+  -e KAFKA_NODE_ID=1 \
+  -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT \
+  -e KAFKA_LISTENERS=PLAINTEXT://localhost:9092,CONTROLLER://localhost:9093 \
+  -e KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT \
+  -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+  -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 \
+  -e KAFKA_LOG_DIRS=/var/lib/kafka/data \
+  -e KAFKA_METADATA_LOG_DIR=/var/lib/kafka/metadata \
+  -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+  -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 \
+  -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1 \
+  -e KAFKA_AUTO_CREATE_TOPICS_ENABLE=true \
+  -e CLUSTER_ID=249bc7a8-fb46-4a8f-8d24-14ffaa2ecdb1 \
+  -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@localhost:9093 \
+  -v kafka-data:/var/lib/kafka/data \
+  -v kafka-logs:/var/lib/kafka/metadata \
+  --network 5277f0ffb171fb299f7cc7ec269fa35609e02c8f69ae09bb692b5f2c557a3e85 \
+  confluentinc/cp-kafka:7.9.0
+


### PR DESCRIPTION
Description:
This pull request introduces the initial setup for managing Kafka alerts using Docker scripts. The changes include scripts to create topics, list topics, send alerts, and receive alerts on a Kafka instance running in KRaft mode (Zookeeper-less). This setup is designed to facilitate the creation and management of Kafka topics for alert messaging.

Key Features:
Create Alerts Topic: Initializes the alerts topic on the kafka-alerts instance.
List Topics: Displays the list of topics on the kafka-alerts instance.
Send Alerts: Publishes messages to the alerts topic.
Receive Alerts: Consumes messages from the alerts topic.
Start Kafka in KRaft Mode: Configures and starts Kafka without Zookeeper.